### PR TITLE
Don't strip space from python completions

### DIFF
--- a/lisp/progmodes/python.el
+++ b/lisp/progmodes/python.el
@@ -3551,7 +3551,7 @@ completion."
                  (split-string
                   (buffer-substring-no-properties
                    (line-beginning-position) (point-min))
-                  "[ \f\t\n\r\v()]+" t)
+                  "[\f\t\n\r\v()]+" t)
                  :test #'string=))))
         (set-process-filter process original-filter-fn)))))
 


### PR DESCRIPTION
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=24322
https://lists.gnu.org/archive/html/bug-gnu-emacs/2016-08/msg00975.html

```
The returned completion deliberately includes a space after a word like
'import', which is always followed by more words.

* lisp/progmodes/python.el (python-shell-completion-native-get-completions):
Remove space from regular expression character class
```
